### PR TITLE
Fix zoom control display and activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,11 @@
 
             function updateButtons() {
                 // Zoom controls
-                $zoomWrap.classList.toggle('d-none', !hasZoom || state === 'stopped');
-                $btnZoomReset.classList.toggle('d-none', !hasZoom || state === 'stopped');
+                const showZoom = hasZoom && state !== 'stopped';
+                $zoomWrap.classList.toggle('d-none', !showZoom);
+                $btnZoomReset.classList.toggle('d-none', !showZoom);
+                // Disable zoom slider when paused or zoom unsupported
+                $zoomRange.disabled = !hasZoom || state !== 'running';
 
                 // Torch
                 $btnTorch.classList.toggle('d-none', !hasTorch || state === 'stopped');
@@ -112,7 +115,7 @@
                         : null;
 
                     // Zoom
-                    if (caps && 'zoom' in caps) {
+                    if (caps && typeof caps.zoom !== 'undefined') {
                         hasZoom = true;
                         // zoom can be a number or object (min/max/step). Handle both.
                         if (typeof caps.zoom === 'object') {


### PR DESCRIPTION
## Summary
- Hide zoom controls unless zoom is supported and the scanner is started
- Disable zoom range when paused and improve zoom capability detection

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2066f17408327afb813a7c8782067