### PR TITLE
Reset zoom controls when stopping scanner

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,11 +21,11 @@
                         </div>
                         <div class="card-body">
                             <div id="zoom-in-out" class="d-flex justify-content-between mb-3 d-none">
-                                <div id="zoom-min" class="small text-muted">0.5x</div>
+                                <div id="zoom-min" class="small text-muted">x</div>
                                 <div class="flex-grow-1 mx-3">
                                     <input id="zoom-range" type="range" class="custom-range" />
                                 </div>
-                                <div id="zoom-max" class="small text-muted">10x</div>
+                                <div id="zoom-max" class="small text-muted">x</div>
                             </div>
                             <div class="d-flex justify-content-between">
                                 <button id="torch" type="button" class="btn btn-primary px-2 rounded-pill d-none" title="Torch"><i class="fa-solid fa-bolt-lightning fa-fw"></i></button>
@@ -255,6 +255,18 @@
                     // noop
                 } finally {
                     state = 'stopped';
+                    // Reset zoom UI to default placeholders
+                    hasZoom = false;
+                    zoomDefault = 1;
+                    zoomMin = 1;
+                    zoomMax = 1;
+                    zoomStep = 0.1;
+                    $zoomRange.value = 1;
+                    $zoomRange.min = 1;
+                    $zoomRange.max = 1;
+                    $zoomRange.step = 0.1;
+                    $zoomMin.textContent = 'x';
+                    $zoomMax.textContent = 'x';
                     setStatus('Lector detenido.');
                     updateButtons();
                 }


### PR DESCRIPTION
## Summary
- Hide zoom UI by default and display placeholders until zoom capabilities are known
- Reset zoom slider and labels and hide controls when the scanner stops

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c208fd9734832795a0198a40a6708c