### PR TITLE
feat: restrict scanner to QR codes

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,8 +200,14 @@
 
                 const config = {
                     fps: 30,
-                    // qrbox opcional: dejar pantalla completa del contenedor (ya es 1:1)
-                    rememberLastUsedCamera: true
+                    // Asegura un área de escaneo cuadrada para ocupar todo el contenedor
+                    qrbox: (viewfinderWidth, viewfinderHeight) => {
+                        const minEdge = Math.min(viewfinderWidth, viewfinderHeight);
+                        return { width: minEdge, height: minEdge };
+                    },
+                    rememberLastUsedCamera: true,
+                    supportedScanTypes: [Html5QrcodeScanType.SCAN_TYPE_CAMERA],
+                    formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE]
                 };
 
                 const onScanSuccess = (decodedText, decodedResult) => {


### PR DESCRIPTION
## Summary
- limit scanner to camera-only QR code reading
- ensure video fills container using square qrbox

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c20fffb04c83279e6d1d0b877fe022