### PR TITLE
Prefer rear camera when available

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,19 +233,37 @@
                 };
 
                 try {
+                    let started = false;
                     try {
-                        await html5QrCode.start(cameraConfigStrict, config, onScanSuccess, onScanFailure);
-                    } catch (_) {
-                        // If strict constraints fail, the html5-qrcode instance can remain
-                        // in a transitional state. Recreate it before retrying to avoid
-                        // "Cannot transition to a new state" errors.
-                        try {
-                            await html5QrCode.clear();
-                        } catch (_) {
-                            /* ignore */
+                        const devices = await Html5Qrcode.getCameras();
+                        const backCamera = devices.find((d) => /back|rear|environment|world/i.test(d.label));
+                        if (backCamera) {
+                            await html5QrCode.start(
+                                { deviceId: { exact: backCamera.id } },
+                                config,
+                                onScanSuccess,
+                                onScanFailure
+                            );
+                            started = true;
                         }
-                        html5QrCode = new Html5Qrcode("html5-qrcode");
-                        await html5QrCode.start(cameraConfigFallback, config, onScanSuccess, onScanFailure);
+                    } catch (_) {
+                        /* ignore and fallback */
+                    }
+                    if (!started) {
+                        try {
+                            await html5QrCode.start(cameraConfigStrict, config, onScanSuccess, onScanFailure);
+                        } catch (_) {
+                            // If strict constraints fail, the html5-qrcode instance can remain
+                            // in a transitional state. Recreate it before retrying to avoid
+                            // "Cannot transition to a new state" errors.
+                            try {
+                                await html5QrCode.clear();
+                            } catch (_) {
+                                /* ignore */
+                            }
+                            html5QrCode = new Html5Qrcode("html5-qrcode");
+                            await html5QrCode.start(cameraConfigFallback, config, onScanSuccess, onScanFailure);
+                        }
                     }
                     state = 'running';
                     setStatus('Lector iniciado.');


### PR DESCRIPTION
## Summary
- Choose rear-facing camera explicitly when available.
- Fall back to facingMode constraints if no rear camera is detected.

## Testing
- `npm test` (fails: ENOENT cannot find package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c21659b324832792e1cbc26c117225