### PR TITLE
Mostrar nivel de zoom en status al deslizar

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,8 +125,12 @@
             let zoomMax = 1;
             let zoomStep = 0.1;
             let currentZoom = 1;
+            let statusMessage = '';
 
-            function setStatus(msg) { $status.textContent = msg || ''; }
+            function setStatus(msg, persist = true) {
+                if (persist) statusMessage = msg || '';
+                $status.textContent = msg || '';
+            }
 
             function updateButtons() {
                 // Zoom controls
@@ -406,7 +410,13 @@
 
             $zoomRange.addEventListener('input', (e) => {
                 if (!hasZoom || state === 'stopped') return;
+                const val = Math.round(e.target.value * 100) / 100;
+                setStatus('Zoom: ' + val + 'x', false);
                 applyZoom(e.target.value);
+            });
+
+            $zoomRange.addEventListener('change', () => {
+                setStatus(statusMessage);
             });
 
             // Estado inicial


### PR DESCRIPTION
## Summary
- Conserva el texto de status pero muestra temporalmente el nivel de zoom durante el deslizamiento.
- Restaura el mensaje de status original al terminar de ajustar el zoom.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2690fb2348327933d1bf38a763a8e