### PR TITLE
Position status bar at top and hide on pause

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,8 @@
             #status {
                 display: block;
                 position: absolute;
-                bottom: 0;
+                top: 0;
+                left: 0;
                 z-index: 1;
                 background: rgba(9, 9, 9, 0.46);
                 color: rgb(255, 236, 236);
@@ -130,6 +131,7 @@
             function setStatus(msg, persist = true) {
                 if (persist) statusMessage = msg || '';
                 $status.textContent = msg || '';
+                $status.style.display = state === 'paused' ? 'none' : 'block';
             }
 
             function updateButtons() {


### PR DESCRIPTION
## Summary
- Move custom status bar to top of reader viewport
- Hide custom status bar when scanner is paused so library message shows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c26be371e88327b6760be0a0f6fe52