### PR TITLE
Fix torch button class toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,6 +243,7 @@
                 try {
                     await html5QrCode.applyVideoConstraints({ advanced: [{ torch: !!on }] });
                     torchOn = !!on;
+                    $btnTorch.classList.toggle('btn-dark', !torchOn);
                     $btnTorch.classList.toggle('btn-warning', torchOn);
                 } catch (err) {
                     console.warn('Torch not applied:', err);


### PR DESCRIPTION
## Summary
- Ensure torch button switches between `btn-dark` and `btn-warning` according to torch state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2744e5a948327bf3e1c041ee3cc67