### PR TITLE
Reset torch button style when camera stops

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,6 +384,11 @@
                     $zoomRange.step = 0.1;
                     $zoomMin.textContent = 'x';
                     $zoomMax.textContent = 'x';
+                    // Reset torch state when no camera is active
+                    hasTorch = false;
+                    torchOn = false;
+                    $btnTorch.classList.add('btn-dark');
+                    $btnTorch.classList.remove('btn-warning');
                     setStatus('Scanner detenido');
                     updateButtons();
                 }


### PR DESCRIPTION
## Summary
- Reset torch state and button style when scanner stops or no camera is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2757299d88327802206b672bc3cd0