### PR TITLE
Alterna el lector QR entre abierto y cerrado

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,9 @@
             const $btnPause = el('pause');
             const $btnStop = el('stop');
             const $btnZoomReset = el('zoom');
+            const $btnClose = el('close');
+            const $btnOpen = el('open');
+            const $lectorQr = el('lector-qr');
             const $status = el('status');
 
             // Scanner
@@ -468,6 +471,16 @@
 
             $zoomRange.addEventListener('change', () => {
                 setStatus(statusMessage);
+            });
+
+            $btnClose.addEventListener('click', () => {
+                $lectorQr.classList.remove('abierto');
+                $lectorQr.classList.add('cerrado');
+            });
+
+            $btnOpen.addEventListener('click', () => {
+                $lectorQr.classList.remove('cerrado');
+                $lectorQr.classList.add('abierto');
             });
 
             // Estado inicial


### PR DESCRIPTION
## Summary
- Añade referencias a los botones `open` y `close` y al contenedor `lector-qr`
- Alterna las clases `abierto` y `cerrado` al presionar los botones correspondientes

## Testing
- `npm test` *(falló: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c482059ae08327ab491978a5e21bdf