### PR TITLE
Ocultar control de restablecer zoom en nivel por defecto

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,11 +184,12 @@
                 // add it back when showing to avoid conflicts with `d-none`.
                 $zoomWrap.classList.toggle('d-flex', showZoom);
                 $zoomWrap.classList.toggle('d-none', !showZoom);
-                $btnZoomReset.classList.toggle('d-none', !showZoom);
                 // Disable zoom slider when paused or zoom unsupported
                 $zoomRange.disabled = !hasZoom || state !== 'running';
-                // Enable reset only when zoom differs from default
-                $btnZoomReset.disabled = !hasZoom || state !== 'running' || currentZoom === zoomDefault;
+                // Show reset only when zoom differs from default
+                const showZoomReset = showZoom && currentZoom !== zoomDefault;
+                $btnZoomReset.classList.toggle('d-none', !showZoomReset);
+                $btnZoomReset.disabled = !hasZoom || state !== 'running';
 
                 // Torch
                 $btnTorch.classList.toggle('d-none', !hasTorch || state === 'stopped');


### PR DESCRIPTION
## Summary
- Oculta el botón de reset del zoom cuando el zoom está en su valor por defecto y lo muestra sólo si cambia.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c488826740832798956e28c5a06699